### PR TITLE
fix(swarm): stack redeploy breaks the mount of relative path [EE-4646]

### DIFF
--- a/deploy.go
+++ b/deploy.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	libstack "github.com/portainer/docker-compose-wrapper"
 	"github.com/portainer/docker-compose-wrapper/compose"
@@ -54,9 +55,10 @@ func (cmd *DeployCommand) Run(cmdCtx *CommandExecutionContext) error {
 
 		cmdCtx.logger.Infow("Creating target destination directory on disk", "directory", mountPath)
 		gitOptions := git.CloneOptions{
-			URL:   cmd.GitRepository,
-			Auth:  getAuth(cmd.User, cmd.Password),
-			Depth: 1,
+			URL:           cmd.GitRepository,
+			ReferenceName: plumbing.ReferenceName(cmd.Reference),
+			Auth:          getAuth(cmd.User, cmd.Password),
+			Depth:         1,
 		}
 
 		cmdCtx.logger.Infow("Cloning git repository", "path", clonePath, "cloneOptions", gitOptions)
@@ -117,6 +119,25 @@ func (cmd *SwarmDeployCommand) Run(cmdCtx *CommandExecutionContext) error {
 
 	mountPath := makeWorkingDir(cmd.Destination, cmd.ProjectName)
 	clonePath := path.Join(mountPath, repositoryName)
+
+	// Check if the directory exists. If yes, the process is doing stack redeployment.
+	forceUpdate := false
+	info, err := os.Stat(clonePath)
+	if err == nil && info.IsDir() {
+		forceUpdate = true
+	}
+
+	// Record running services before deployment/redeployment
+	serviceIDs, err := checkRunningService(cmdCtx.logger, *cmd)
+	if err != nil {
+		return err
+	}
+
+	runningServices := make(map[string]struct{}, 0)
+	for _, serviceID := range serviceIDs {
+		runningServices[serviceID] = struct{}{}
+	}
+
 	if !cmd.Keep { //stack create request
 		_, err := os.Stat(mountPath)
 		if err == nil {
@@ -134,9 +155,10 @@ func (cmd *SwarmDeployCommand) Run(cmdCtx *CommandExecutionContext) error {
 
 		cmdCtx.logger.Infow("Creating target destination directory on disk", "directory", mountPath)
 		gitOptions := git.CloneOptions{
-			URL:   cmd.GitRepository,
-			Auth:  getAuth(cmd.User, cmd.Password),
-			Depth: 100,
+			URL:           cmd.GitRepository,
+			ReferenceName: plumbing.ReferenceName(cmd.Reference),
+			Auth:          getAuth(cmd.User, cmd.Password),
+			Depth:         100,
 		}
 
 		cmdCtx.logger.Infow("Cloning git repository", "path", clonePath, "cloneOptions", gitOptions)
@@ -148,34 +170,27 @@ func (cmd *SwarmDeployCommand) Run(cmdCtx *CommandExecutionContext) error {
 		}
 	}
 
-	command := path.Join(BIN_PATH, "docker")
-	if runtime.GOOS == "windows" {
-		command = path.Join(BIN_PATH, "docker.exe")
-	}
-	args := make([]string, 0)
-
-	if cmd.Prune {
-		args = append(args, "stack", "deploy", "--prune", "--with-registry-auth")
-	} else {
-		args = append(args, "stack", "deploy", "--with-registry-auth")
-	}
-	if !cmd.Pull {
-		args = append(args, "--resolve-image=never")
-	}
-
-	for _, cfile := range cmd.ComposeRelativeFilePaths {
-		args = append(args, "--compose-file", path.Join(clonePath, cfile))
-	}
-	cmdCtx.logger.Infow("Deploying Swarm stack", "composeFilePaths", cmd.ComposeRelativeFilePaths,
-		"workingDirectory", clonePath, "projectName", cmd.ProjectName)
-	args = append(args, cmd.ProjectName)
-
-	err := runCommandAndCaptureStdErr(command, args, cmd.Env, clonePath)
+	err = deploySwarmStack(cmdCtx.logger, *cmd, clonePath)
 	if err != nil {
-		cmdCtx.logger.Errorw("Failed to swarm deplot Git repository", "error", err)
-		return errDeployComposeFailure
+		return err
 	}
-	cmdCtx.logger.Info("Swarm stack deployment complete")
+
+	if forceUpdate {
+		// If the process executes redeployment, the running services need
+		// to be recreated forcibly
+		updatedServiceIDs, err := checkRunningService(cmdCtx.logger, *cmd)
+		if err != nil {
+			return err
+		}
+
+		for _, updatedServiceID := range updatedServiceIDs {
+			_, ok := runningServices[updatedServiceID]
+			if ok {
+				_ = updateService(cmdCtx.logger, *cmd, updatedServiceID)
+			}
+		}
+	}
+
 	return nil
 }
 
@@ -197,6 +212,23 @@ func runCommandAndCaptureStdErr(command string, args []string, env []string, wor
 	return nil
 }
 
+func runCommand(command string, args []string) (string, error) {
+	var (
+		stderr bytes.Buffer
+		stdout bytes.Buffer
+	)
+	cmd := exec.Command(command, args...)
+	cmd.Stderr = &stderr
+	cmd.Stdout = &stdout
+
+	err := cmd.Run()
+	if err != nil {
+		return stdout.String(), errors.New(stderr.String())
+	}
+
+	return stdout.String(), nil
+}
+
 func getAuth(username, password string) *http.BasicAuth {
 	if password != "" {
 		if username == "" {
@@ -212,4 +244,12 @@ func getAuth(username, password string) *http.BasicAuth {
 
 func makeWorkingDir(target, stackName string) string {
 	return filepath.Join(target, "stacks", stackName)
+}
+
+func getDockerBinaryPath() string {
+	command := path.Join(BIN_PATH, "docker")
+	if runtime.GOOS == "windows" {
+		command = path.Join(BIN_PATH, "docker.exe")
+	}
+	return command
 }

--- a/swarm.go
+++ b/swarm.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"path"
+	"runtime"
+	"strings"
+
+	"go.uber.org/zap"
+)
+
+func deploySwarmStack(logger *zap.SugaredLogger, cmd SwarmDeployCommand, clonePath string) error {
+	command := getDockerBinaryPath()
+	args := make([]string, 0)
+
+	if cmd.Prune {
+		args = append(args, "stack", "deploy", "--prune", "--with-registry-auth")
+	} else {
+		args = append(args, "stack", "deploy", "--with-registry-auth")
+	}
+	if !cmd.Pull {
+		args = append(args, "--resolve-image=never")
+	}
+
+	for _, cfile := range cmd.ComposeRelativeFilePaths {
+		args = append(args, "--compose-file", path.Join(clonePath, cfile))
+	}
+	logger.Infow("Deploying Swarm stack", "composeFilePaths", cmd.ComposeRelativeFilePaths,
+		"workingDirectory", clonePath, "projectName", cmd.ProjectName)
+	args = append(args, cmd.ProjectName)
+
+	err := runCommandAndCaptureStdErr(command, args, cmd.Env, clonePath)
+	if err != nil {
+		logger.Errorw("Failed to swarm deploy Git repository", "error", err)
+		return errDeployComposeFailure
+	}
+	logger.Info("Swarm stack deployment complete")
+
+	return err
+}
+
+func checkRunningService(logger *zap.SugaredLogger, cmd SwarmDeployCommand) ([]string, error) {
+	command := getDockerBinaryPath()
+	// stack services "--format={{.ID}}"
+	args := []string{"stack", "services", "--format={{.ID}}", cmd.ProjectName}
+
+	logger.Infow("Checking Swarm stack", "args", args)
+	output, err := runCommand(command, args)
+	if err != nil {
+		logger.Errorw("Failed to check running swarm services", "error", err)
+		return nil, err
+	}
+
+	serviceIDs := splitLines(string(output))
+	logger.Infow("Checking stack services", "service IDs", serviceIDs)
+	return serviceIDs, nil
+}
+
+func updateService(logger *zap.SugaredLogger, cmd SwarmDeployCommand, serviceID string) error {
+	command := getDockerBinaryPath()
+	args := []string{"service", "update", serviceID}
+
+	logger.Infow("Updating Swarm service", "args", args)
+	_, err := runCommand(command, args)
+	if err != nil {
+		logger.Errorw("Failed to update swarm services", "error", err)
+		return err
+	}
+
+	logger.Info("Update stack service completed")
+	return nil
+}
+
+func splitLines(s string) []string {
+	var separator string
+	if runtime.GOOS == "windows" {
+		separator = "\r\n"
+	} else {
+		separator = "\n"
+	}
+	parts := strings.Split(s, separator)
+
+	ret := []string{}
+	for _, part := range parts {
+		// remove empty string
+		if part != "" {
+			ret = append(ret, part)
+		}
+	}
+	return ret
+}

--- a/swarm.go
+++ b/swarm.go
@@ -40,7 +40,6 @@ func deploySwarmStack(logger *zap.SugaredLogger, cmd SwarmDeployCommand, clonePa
 
 func checkRunningService(logger *zap.SugaredLogger, cmd SwarmDeployCommand) ([]string, error) {
 	command := getDockerBinaryPath()
-	// stack services "--format={{.ID}}"
 	args := []string{"stack", "services", "--format={{.ID}}", cmd.ProjectName}
 
 	logger.Infow("Checking Swarm stack", "args", args)

--- a/swarm.go
+++ b/swarm.go
@@ -38,9 +38,9 @@ func deploySwarmStack(logger *zap.SugaredLogger, cmd SwarmDeployCommand, clonePa
 	return err
 }
 
-func checkRunningService(logger *zap.SugaredLogger, cmd SwarmDeployCommand) ([]string, error) {
+func checkRunningService(logger *zap.SugaredLogger, projectName string) ([]string, error) {
 	command := getDockerBinaryPath()
-	args := []string{"stack", "services", "--format={{.ID}}", cmd.ProjectName}
+	args := []string{"stack", "services", "--format={{.ID}}", projectName}
 
 	logger.Infow("Checking Swarm stack", "args", args)
 	output, err := runCommand(command, args)
@@ -54,9 +54,9 @@ func checkRunningService(logger *zap.SugaredLogger, cmd SwarmDeployCommand) ([]s
 	return serviceIDs, nil
 }
 
-func updateService(logger *zap.SugaredLogger, cmd SwarmDeployCommand, serviceID string) error {
+func updateService(logger *zap.SugaredLogger, serviceID string) error {
 	command := getDockerBinaryPath()
-	args := []string{"service", "update", serviceID}
+	args := []string{"service", "update", serviceID, "--force"}
 
 	logger.Infow("Updating Swarm service", "args", args)
 	_, err := runCommand(command, args)

--- a/types.go
+++ b/types.go
@@ -21,6 +21,7 @@ type DeployCommand struct {
 	Keep                     bool     `help:"Keep stack folder" short:"k"`
 	Env                      []string `help:"OS ENV for stack" example:"key=value"`
 	GitRepository            string   `arg:"" help:"Git repository to deploy from." name:"git-repo"`
+	Reference                string   `arg:"" help:"Reference of Git repository to deploy from." name:"git-ref"`
 	ProjectName              string   `arg:"" help:"Name of the Compose stack." name:"project-name"`
 	Destination              string   `arg:"" help:"Path on disk where the Git repository will be cloned." type:"path" name:"destination"`
 	ComposeRelativeFilePaths []string `arg:"" help:"Relative path to the Compose file."  name:"compose-file-paths"`
@@ -35,6 +36,7 @@ type SwarmDeployCommand struct {
 	Env                      []string `help:"OS ENV for stack."`
 	GitRepository            string   `arg:"" help:"Git repository to deploy from." name:"git-repo"`
 	ProjectName              string   `arg:"" help:"Name of the Swarm stack." name:"project-name"`
+	Reference                string   `arg:"" help:"Reference of Git repository to deploy from." name:"git-ref"`
 	Destination              string   `arg:"" help:"Path on disk where the Git repository will be cloned." type:"path" name:"destination"`
 	ComposeRelativeFilePaths []string `arg:"" help:"Relative path to the Compose file."  name:"compose-file-paths"`
 }

--- a/types.go
+++ b/types.go
@@ -35,8 +35,8 @@ type SwarmDeployCommand struct {
 	Keep                     bool     `help:"Keep stack folder" short:"k"`
 	Env                      []string `help:"OS ENV for stack."`
 	GitRepository            string   `arg:"" help:"Git repository to deploy from." name:"git-repo"`
-	ProjectName              string   `arg:"" help:"Name of the Swarm stack." name:"project-name"`
 	Reference                string   `arg:"" help:"Reference of Git repository to deploy from." name:"git-ref"`
+	ProjectName              string   `arg:"" help:"Name of the Swarm stack." name:"project-name"`
 	Destination              string   `arg:"" help:"Path on disk where the Git repository will be cloned." type:"path" name:"destination"`
 	ComposeRelativeFilePaths []string `arg:"" help:"Relative path to the Compose file."  name:"compose-file-paths"`
 }


### PR DESCRIPTION
closes [EE-4646]

The solution of `portainer-unpacker` is to run the command `docker service update <stack_service_id>` every time when the stack redeployment is executed. This command will forcibly re-create a service container so that the relative path of the new downloaded git repository can be mounted again.

[EE-4646]: https://portainer.atlassian.net/browse/EE-4646?