### PR TITLE
fix(binaries): update binary versions to match portainer api server [EE-6744]

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -3,8 +3,8 @@ set -euo pipefail
 IFS=$'\n\t'
 PLATFORM=${1:-"linux"}
 ARCH=${2:-"amd64"}
-DOCKER_VERSION="v20.10.9"
-DOCKER_COMPOSE_VERSION="v2.5.1"
+DOCKER_VERSION="v24.0.7"
+DOCKER_COMPOSE_VERSION="v2.23.3"
 mkdir -p dist/
 
 /usr/bin/env bash ./build/download_docker_binary.sh "$PLATFORM" "$ARCH" "$DOCKER_VERSION"


### PR DESCRIPTION
[EE-6744]

- [ ] after this is merged create a PR to master from develop to publish.

[EE-6744]: https://portainer.atlassian.net/browse/EE-6744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ