### PR TITLE
chore(go): update to Go v1.22.5 EE-7297

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/portainer/compose-unpacker
 
-go 1.21
+go 1.22
 
-toolchain go1.21.9
+toolchain go1.22.5
 
 require (
 	github.com/alecthomas/kong v0.6.1


### PR DESCRIPTION
[EE-7297]

[EE-7297]: https://portainer.atlassian.net/browse/EE-7297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Ref BE-2296