### PR TITLE
2024-09-CVE

### DIFF
--- a/build/windows/Dockerfile
+++ b/build/windows/Dockerfile
@@ -1,7 +1,7 @@
 ARG OSVERSION
 FROM --platform=linux/amd64 gcr.io/k8s-staging-e2e-test-images/windows-servercore-cache:1.0-linux-amd64-${OSVERSION} as core
 FROM --platform=linux/amd64 alpine:3.13.0 as downloader
-ENV GIT_VERSION 2.45.2
+ENV GIT_VERSION 2.46.0
 ENV GIT_PATCH_VERSION 1
 
 RUN mkdir mingit/ \

--- a/build/windows/Dockerfile
+++ b/build/windows/Dockerfile
@@ -1,7 +1,7 @@
 ARG OSVERSION
 FROM --platform=linux/amd64 gcr.io/k8s-staging-e2e-test-images/windows-servercore-cache:1.0-linux-amd64-${OSVERSION} as core
 FROM --platform=linux/amd64 alpine:3.13.0 as downloader
-ENV GIT_VERSION 2.44.0
+ENV GIT_VERSION 2.45.2
 ENV GIT_PATCH_VERSION 1
 
 RUN mkdir mingit/ \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/portainer/compose-unpacker
 
-go 1.22.6
+go 1.22.7
 
 require (
 	github.com/alecthomas/kong v0.6.1

--- a/setup.sh
+++ b/setup.sh
@@ -3,8 +3,8 @@ set -euo pipefail
 IFS=$'\n\t'
 PLATFORM=${1:-"linux"}
 ARCH=${2:-"amd64"}
-DOCKER_VERSION="v24.0.9"
-DOCKER_COMPOSE_VERSION="v2.26.1"
+DOCKER_VERSION="v27.1.2"
+DOCKER_COMPOSE_VERSION="v2.29.2"
 mkdir -p dist/
 
 /usr/bin/env bash ./build/download_docker_binary.sh "$PLATFORM" "$ARCH" "$DOCKER_VERSION"


### PR DESCRIPTION
cli tool updates -
DOCKER_VERSION="v27.1.2"
DOCKER_COMPOSE_VERSION="v2.29.2"
mingit 2.46.0 (CVE-2021-24112) (CVE-2024-30105)